### PR TITLE
fix: 画面を下にスクロールするとヘッダが見えなくなってしまうので、上部に固定する

### DIFF
--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -4,9 +4,10 @@ body {
 
 .header {
     display: flex;
-    position: fixed;
+    position: -webkit-sticky;
+    position: sticky;
+
     top: 0;
-    left: 0;
     padding: 0 20px;
     justify-content: space-between;
     align-items: center;
@@ -14,6 +15,7 @@ body {
     background: #000;
     width: 100%;
     height: 82px;
+    z-index: 1000;
 }
 
 .header-logo {
@@ -69,4 +71,8 @@ body {
 
     font-size: 24px;
     cursor: pointer;
+}
+
+.main {
+    margin-top: 82px;
 }

--- a/src/resources/views/layouts/common.blade.php
+++ b/src/resources/views/layouts/common.blade.php
@@ -13,6 +13,8 @@
 </head>
 <body>
     @include('parts.header')
-    @yield('content')
+    <main class="main">
+        @yield('content')
+    </main>
 </body>
 </html>


### PR DESCRIPTION
ヘッダのレイアウト修正。