### PR TITLE
fix: ヘッダのログイン／ログアウトボタンのスタイルが通常のボタンのままだったため修正する

### DIFF
--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -57,6 +57,17 @@ body {
     font-size: 24px;
 }
 
+.header-nav__logout-button button,
+.header-nav__login-button button {
+    width: 100%;
+    height: 50px;
+    background: #000;
+    color: #fff;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
 .header-nav__exhibition {
     display: inline-block;
     padding: 0 15px;


### PR DESCRIPTION
 ヘッダのログイン／ログアウトボタンのスタイル修正