### PR TITLE
fix: ログイン画面のユーザー名の文言を削除する

### DIFF
--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -9,9 +9,9 @@
         <h1>ログイン</h1>
         <form class="form" method="POST" action="{{url('login')}}">
             @csrf
-            {{-- ユーザー名もしくはメールアドレス --}}
+            {{-- メールアドレス --}}
             <div class="form__item">
-                <div class="form__item-label">ユーザー名 / メールアドレス</div>
+                <div class="form__item-label">メールアドレス</div>
                 <input class="form__item-input" type="text" name="email">
                 <div class="form__item-alert">{{$errors->first('email')}}</div>
             </div>


### PR DESCRIPTION
文言修正。
ログインにはメールアドレスとパスワードのみで良い。