### PR TITLE
fix: マイグレーション実行時にユーザーが無駄に作成されていたため修正する

### DIFF
--- a/src/database/seeders/ItemsTableSeeder.php
+++ b/src/database/seeders/ItemsTableSeeder.php
@@ -21,6 +21,7 @@ class ItemsTableSeeder extends Seeder
         $params = [
             [
                 'name' => '腕時計',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '1',
                 'price' => 15000,
@@ -29,6 +30,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'HDD',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '2',
                 'price' => 5000,
@@ -37,6 +39,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => '玉ねぎ3束',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '3',
                 'price' => 300,
@@ -45,6 +48,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => '革靴',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '4',
                 'price' => 4000,
@@ -53,6 +57,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'ノートPC',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '1',
                 'price' => 45000,
@@ -61,6 +66,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'マイク',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '2',
                 'price' => 8000,
@@ -69,6 +75,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'ショルダーバッグ',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '3',
                 'price' => 3500,
@@ -77,6 +84,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'タンブラー',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '4',
                 'price' => 500,
@@ -85,6 +93,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'コーヒーミル',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '1',
                 'price' => 4000,
@@ -93,6 +102,7 @@ class ItemsTableSeeder extends Seeder
             ],
             [
                 'name' => 'メイクセット',
+                'owner_id' => 1,
                 'brand_name' => 'ノーブランド',
                 'condition_id' => '2',
                 'price' => 2500,

--- a/src/tests/Feature/ItemsTest.php
+++ b/src/tests/Feature/ItemsTest.php
@@ -34,7 +34,9 @@ class ItemsTest extends TestCase
     */
     public function test_can_get_all_items(): void
     {
-        $items = Item::factory(10)->create();
+        $items = Item::factory(10)->create([
+            'owner_id' => User::factory()->create()->id,
+        ]);
         $response = $this->get('/');
         foreach ($items as $item) {
             $response->assertSee($item->name);
@@ -53,6 +55,7 @@ class ItemsTest extends TestCase
     {
         /* 購入済みの商品を作成 */
         $soldItem = Item::factory()->create([
+            'owner_id' => User::factory()->create()->id,
             'stock' => 0,
         ]);
         


### PR DESCRIPTION
ItemTestでItem作成時にowner_idがないための処理だったが、ItemTest内でUserを作成することで解決